### PR TITLE
Add Google Maps links using address instead of facility name

### DIFF
--- a/dashboard.qmd
+++ b/dashboard.qmd
@@ -116,7 +116,7 @@ tbl_data <- bccc |>
       paste0(" (last seen ", format(last_vacancy_gr1_age12, "%Y-%m-%d"), ")"),
       ""
     ),
-    maps_query = paste0(NAME, ", ", ADDRESS_1, ", ", CITY),
+    maps_query = paste0(ADDRESS_1, ", ", CITY, ", BC"),
     maps_url = paste0("https://www.google.com/maps/search/", URLencode(maps_query)),
     popup = glue::glue(
       "<b>{NAME}</b>",
@@ -413,7 +413,7 @@ row_details <- function(index, bccc) {
           'Google Maps',
           htmltools::a(
             "View on Google Maps",
-            href = paste0("https://www.google.com/maps/search/", URLencode(paste0(bccc$NAME, ", ", bccc$ADDRESS_1, ", ", bccc$CITY))),
+            href = paste0("https://www.google.com/maps/search/", URLencode(paste0(bccc$ADDRESS_1, ", ", bccc$CITY, ", BC"))),
             target = "_blank"
           )
         ),


### PR DESCRIPTION
## Summary

- Adds address and Google Maps link to leaflet map popups and table row details
- Fixes Maps query to use street address + city + BC instead of facility name, which was unreliable

## Test plan

- [ ] Render dashboard locally
- [ ] Click "View on Google Maps" in a map popup — confirm it navigates to the correct address
- [ ] Click "View on Google Maps" in a table row detail — confirm same
- [ ] Test a facility with a generic/ambiguous name to verify address-based search is more accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)